### PR TITLE
Allow server time to start

### DIFF
--- a/boostrap.sh
+++ b/boostrap.sh
@@ -11,5 +11,6 @@ touch "$NOIDSLOG"
 cat /dev/null > "$NOIDSLOG"
 
 noids -log "$NOIDSLOG" &
+sleep 1
 curl --data 'name=dev&template=.rddddd' localhost:13001/pools
 tail -f "$NOIDSLOG"


### PR DESCRIPTION
Configuration information must be POSTed after the server has been
started in order for it to receive the request.